### PR TITLE
Move leaflet to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,10 @@
     "enzyme-to-json": "^3.2.2",
     "gh-pages": "^1.0.0",
     "jest": "^21.2.1",
+    "leaflet": "^1.3.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
+    "react-leaflet": "^1.9.1",
     "react-test-renderer": "^16.2.0",
     "release-it": "^7.4.5"
   },
@@ -66,9 +68,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "leaflet": "^1.3.1",
-    "prop-types": "^15.6.1",
-    "react-leaflet": "^1.9.1"
+    "prop-types": "^15.6.1"
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
Since leaflet is not required when using this library it should be under `devDependencies`.

Thanks for your work on this problem!