### PR TITLE
import withStyles directly to avoid pulling in unused modules

### DIFF
--- a/src/grid.js
+++ b/src/grid.js
@@ -1,5 +1,5 @@
 import style from './styled'
-import { Typography } from '@material-ui/core'
+import Typography from '@material-ui/core/Typography'
 
 const GridCore = (
   {

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core';
+import withStyles from '@material-ui/core/styles/withStyles';
 
 const styles = (theme, props, style) => {
     return typeof style === 'function'

--- a/stories/MixedWithStylesSimpleTable.js
+++ b/stories/MixedWithStylesSimpleTable.js
@@ -7,7 +7,7 @@ import _TableCell from '@material-ui/core/TableCell'
 import _TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import _Paper from '@material-ui/core/Paper'
-import { withStyles } from '@material-ui/core/styles';
+import withStyles from '@material-ui/core/styles/withStyles';
 
 
 export const styles = theme => ({


### PR DESCRIPTION
When trying out the implementation on a Gatsby (v2) site, where another module was using material-ui components, it ended up including way more of material-ui than what was expected.

Importing `withStyles` directly, like this PR does, resolved the duplicate imports.